### PR TITLE
Handle disk detachment while cleaning

### DIFF
--- a/cmd/disks_d.go
+++ b/cmd/disks_d.go
@@ -21,6 +21,7 @@ import (
 )
 
 var (
+	detach      bool
 	delDisksCmd = &cobra.Command{
 		Use:     "disks diskname...",
 		Aliases: []string{"disk"},
@@ -35,7 +36,7 @@ var (
 			manager := vcd.DiskManager{
 				Client: vcdClient,
 			}
-			manager.Delete(args)
+			manager.Delete(args, detach)
 		},
 	}
 )
@@ -43,4 +44,5 @@ var (
 func init() {
 	cleanCmd.AddCommand(delDisksCmd)
 	delDisksCmd.Flags().BoolVar(&failifabsent, "failifabsent", false, "command will return non-zero code if the load balancer pool is not there")
+	delDisksCmd.Flags().BoolVar(&detach, "detach", false, "detach all attached VMs before deletion")
 }

--- a/pkg/vcd/app_port.go
+++ b/pkg/vcd/app_port.go
@@ -15,6 +15,7 @@ limitations under the License.
 package vcd
 
 import (
+	"fmt"
 	"log"
 
 	"github.com/vmware/cloud-provider-for-cloud-director/pkg/vcdsdk"
@@ -47,6 +48,7 @@ func (manager *AppPortManager) List() []*types.NsxtAppPortProfile {
 func (manager *AppPortManager) Delete(names []string, failIfAbsent bool, network string) {
 	gateway := getGatewayManager(manager.Client, network)
 	for _, a := range names {
+		fmt.Printf("Deleting app port:[%s]\n", a)
 		err := gateway.DeleteAppPortProfile(a, failIfAbsent)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/vcd/disk.go
+++ b/pkg/vcd/disk.go
@@ -48,6 +48,7 @@ func (manager *DiskManager) List(params DiskListParams) []*types.DiskRecordType 
 
 func (manager *DiskManager) Delete(names []string, detach bool) {
 	for _, name := range names {
+		fmt.Printf("Deleting disk:[%s]\n", name)
 		disks, err := manager.Client.VDC.GetDisksByName(name, false)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/vcd/lb_pool.go
+++ b/pkg/vcd/lb_pool.go
@@ -55,6 +55,7 @@ func (manager *LoadBalancerPoolManager) Delete(names []string, failIfAbsent bool
 	}
 
 	for _, lb := range names {
+		fmt.Printf("Deleting load balancer pool:[%s]\n", lb)
 		err := gateway.DeleteLoadBalancerPool(context.Background(), lb, failIfAbsent)
 		if err != nil {
 			if strings.Contains(err.Error(), "obtained [400]") {

--- a/pkg/vcd/vapp.go
+++ b/pkg/vcd/vapp.go
@@ -15,6 +15,7 @@ limitations under the License.
 package vcd
 
 import (
+	"fmt"
 	"log"
 	"net/url"
 
@@ -43,6 +44,7 @@ func (manager *VappManager) Delete(names []string) {
 	}
 
 	for _, name := range names {
+		fmt.Printf("Deleting vApp:[%s]\n", name)
 		err = m.DeleteVApp(name)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/vcd/virtual_service.go
+++ b/pkg/vcd/virtual_service.go
@@ -68,6 +68,7 @@ func getGatewayManager(c *vcdsdk.Client, network string) *vcdsdk.GatewayManager 
 func (manager *VirtualServiceManager) Delete(names []string, failIfAbsent bool, network string) {
 	gateway := getGatewayManager(manager.Client, network)
 	for _, vs := range names {
+		fmt.Printf("Deleting virtual service:[%s]\n", vs)
 		err := gateway.DeleteVirtualService(context.Background(), vs, failIfAbsent)
 		if err != nil {
 			log.Fatal(err)

--- a/pkg/vcd/vm.go
+++ b/pkg/vcd/vm.go
@@ -63,6 +63,7 @@ func (manager *VmManager) Delete(names []string, vapp string) {
 	}
 
 	for _, vmName := range names {
+		fmt.Printf("Deleting vm:[%s]\n", vmName)
 		vm, err := vApp.GetVMByName(vmName, true)
 		if err != nil {
 			log.Fatal(fmt.Errorf("unable to get vm [%s] in vApp [%s]: [%v]", vmName, vmName, err))


### PR DESCRIPTION
cloud-director api allows vm deletion when there is an unattached disk to the VM. 

We should 
- detach disks from VMs before disk deletion
- ensure we don't delete VMs when there is an attached disk. 